### PR TITLE
refactor JSON parsing with gq

### DIFF
--- a/marzban.sh
+++ b/marzban.sh
@@ -423,8 +423,8 @@ status_command() {
     colorized_echo green "Up"
     
     json=$($COMPOSE -f $COMPOSE_FILE ps -a --format=json)
-    services=$(echo $json | jq -r '.[] | .Service')
-    states=$(echo $json | jq -r '.[] | .State')
+    services=$(echo "$json" | jq -r 'if type == "array" then .[] else . end | .Service')
+    states=$(echo "$json" | jq -r 'if type == "array" then .[] else . end | .State')
     # Print out the service names and statuses
     for i in $(seq 0 $(expr $(echo $services | wc -w) - 1)); do
         service=$(echo $services | cut -d' ' -f $(expr $i + 1))


### PR DESCRIPTION
## Description
This PR addresses an issue in the Bash script related to `marzban status` command. The original code was designed to extract the "Service" and "State" fields from JSON data. However, it was throwing an error when attempting to access these fields when the JSON input was not an array, resulting in a "Cannot index string with string" error.

To resolve this issue, the code has been refactored to handle both array and non-array JSON inputs gracefully. It now checks the type of JSON input and processes it accordingly:

- If the JSON input is an array, it iterates through the elements and extracts the "Service" and "State" fields.
- If the JSON input is not an array, it directly extracts the "Service" and "State" fields.

This modification ensures that the script works correctly with various JSON input formats, preventing errors and enhancing its overall robustness.

## Changes Made
- Refactored the JSON parsing logic to accommodate different JSON input formats.
- Updated the `services` and `states` variables to handle both array and non-array JSON.
- Utilized conditional logic to iterate through JSON elements only when it's an array.

## Testing
Tested the updated script with various JSON inputs, including arrays and non-arrays, to ensure that it parses the "Service" and "State" fields correctly without errors.

## Related Issues
Fix: Gozargah/Marzban#549
