### PR TITLE
Fix ArchLinux detection when using /etc/os-release

### DIFF
--- a/marzban.sh
+++ b/marzban.sh
@@ -70,7 +70,7 @@ detect_and_update_package_manager() {
     elif [ "$OS" == "Fedora"* ]; then
         PKG_MANAGER="dnf"
         $PKG_MANAGER update
-    elif [ "$OS" == "Arch" ]; then
+    elif [[ "$OS" == "Arch"* ]] || [[ "$OS" == "Arch Linux"* ]]; then
         PKG_MANAGER="pacman"
         $PKG_MANAGER -Sy
     elif [[ "$OS" == "openSUSE"* ]]; then
@@ -95,7 +95,7 @@ install_package () {
         $PKG_MANAGER install -y "$PACKAGE"
     elif [ "$OS" == "Fedora"* ]; then
         $PKG_MANAGER install -y "$PACKAGE"
-    elif [ "$OS" == "Arch" ]; then
+    elif [[ "$OS" == "Arch"* ]] || [[ "$OS" == "Arch Linux"* ]]; then
         $PKG_MANAGER -S --noconfirm "$PACKAGE"
     else
         colorized_echo red "Unsupported operating system"


### PR DESCRIPTION
This helps script to recognize Arch Linux install when detected via /etc/os-release rather than /etc/arch-release. Otherwise script will fail in install_package() and detect_and_update_package_manager() functions.